### PR TITLE
Upgraded package versions for Flutter 3.35 - pubspec.yaml

### DIFF
--- a/packages/isar_community_generator/pubspec.yaml
+++ b/packages/isar_community_generator/pubspec.yaml
@@ -12,21 +12,21 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.9.0
-  build: ^2.3.0
+  analyzer: ">=5.0.0 <8.1.1"
+  build: ^2.4.2
   dart_style: ^3.0.1
   dartx: ^1.1.0
   glob: ^2.0.2
   isar_community: 3.2.0-dev.2
   path: ^1.8.1
-  source_gen: ^2.0.0
+  source_gen: ">=1.2.2 <3.1.0"
   xxh3: ^1.0.1
 
 dev_dependencies:
   build_test: ^2.1.5
   matcher: ^0.12.12
   test: ^1.21.0
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^9.0.0
 
 dependency_overrides:
   isar_community:


### PR DESCRIPTION
Flutter 3.35 / Dart 3.9.0 removed package:macros and package:_macros. So, this pubspec should not work very well with Flutter prior 3.35

My first participation ever to an open source project... Sure I missed a lot of procedures ;)

Cheers.