### PR TITLE
Allow Firefox users to use Isar Inspector

### DIFF
--- a/packages/isar_community_inspector/lib/main.dart
+++ b/packages/isar_community_inspector/lib/main.dart
@@ -7,7 +7,8 @@ import 'package:go_router/go_router.dart';
 import 'package:isar_community_inspector/connection_screen.dart';
 
 void main() async {
-  if (window.navigator.userAgent.toLowerCase().contains('chrome')) {
+  if (['chrome', 'firefox'].any((userAgent) =>
+      window.navigator.userAgent.toLowerCase().contains(userAgent))) {
     runApp(
       DarkMode(
         notifier: DarkModeNotifier(),


### PR DESCRIPTION
As a Firefox user this has been a bugbear with the original Isar project for me. This fix allows both Chrome and Firefox user agents to acess Isar Inspector. Previously Firefox would get a _"This browser is not supported. Please use a Chrome based browser."_ error.

Here's a quick test showing Isar Inspector running on Windows in Firefox. Here I've just faked my browser's user-agent to bypass the restriction, but everything appears to work OK so the project should be OK allowing Firefox.

<img width="1749" height="1187" alt="image" src="https://github.com/user-attachments/assets/40f7165d-18fe-4cbf-b9fd-83c4c3a26ab9" />

Thanks