### PR TITLE
Fix analyzer dependency constraint to resolve version conflicts

### DIFF
--- a/packages/isar_community_generator/pubspec.yaml
+++ b/packages/isar_community_generator/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=7.4.5 <7.7.0"
+  analyzer: ">=7.4.5 <9.0.0"
   build: ^3.0.0
   dart_style: ^3.0.1
   dartx: ^1.1.0


### PR DESCRIPTION
🎯 Summary

Updates the `analyzer` dependency range in `isar_community_generator` from `>=7.4.5 <7.7.0` to `>=7.4.5 <9.0.0` to resolve version conflicts with other popular code generators in the Dart ecosystem.

🐛 Problem

The current `analyzer` constraint (`<7.7.0`) prevents `isar_community_generator` from being used alongside modern code generators that require `analyzer >=7.7.1.` This creates dependency resolution failures for projects using multiple generators.

🔧 Solution

Expanded the analyzer version constraint to `>=7.4.5 <9.0.0`, aligning with other mature code generators in the ecosystem.

✅ Compatibility Impact

This change resolves version conflicts with the following commonly-used generators:

| Package              | Version | Analyzer Requirement       | Status                |
|----------------------|---------|----------------------------|-----------------------|
| retrofit_generator   | 10.0.2  | >=7.7.1 <9.0.0             | ✅ Now compatible     |
| freezed              | 3.2.0   | ^8.0.0                     | ✅ Now compatible     |
| injectable_generator | 2.8.1   | >=7.4.0 <9.0.0             | ✅ Remains compatible |
| json_serializable    | 6.11.0  | >=7.4.0 <9.0.0             | ✅ Remains compatible |
| auto_route_generator | 10.2.4  | >=7.4.0 <8.0.0             | ✅ Remains compatible |