### PR TITLE
Upgrade build dependency from ^3.0.0 to ^4.0.0

### DIFF
--- a/packages/isar_community_generator/pubspec.yaml
+++ b/packages/isar_community_generator/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   analyzer: ">=7.4.5 <9.0.0"
-  build: ^3.0.0
+  build: ^4.0.0
   dart_style: ^3.0.1
   dartx: ^1.1.0
   glob: ^2.0.2


### PR DESCRIPTION
build_runner >=2.9.0 depends on build ^4.0.0 and isar_community_generator 3.3.0-dev.3 depends on build ^3.0.0, build_runner >=2.9.0 is incompatible with isar_community_generator 3.3.0-dev.3.

And because no versions of isar_community_generator match >3.3.0-dev.3 <4.0.0, build_runner >=2.9.0 is incompatible with isar_community_generator ^3.3.0-dev.3.