### PR TITLE
Refactor where clause handling in QueryBuilderInternal

### DIFF
--- a/packages/isar_community/lib/src/query_builder.dart
+++ b/packages/isar_community/lib/src/query_builder.dart
@@ -264,10 +264,15 @@ class QueryBuilderInternal<OBJ> {
   /// @nodoc
   @protected
   Query<R> build<R>() {
+    final effectiveWhereClauses = whereClauses.isEmpty &&
+            whereSort == Sort.desc
+        ? const [IdWhereClause.any()]
+        : whereClauses;
+
     return collection!.buildQuery(
       whereDistinct: whereDistinct,
       whereSort: whereSort,
-      whereClauses: whereClauses,
+      whereClauses: effectiveWhereClauses,
       filter: filter,
       sortBy: sortByProperties,
       distinctBy: distinctByProperties,

--- a/packages/isar_test/test/regression/issue_843_sort_test.dart
+++ b/packages/isar_test/test/regression/issue_843_sort_test.dart
@@ -51,7 +51,21 @@ void main() {
     );
 
     await qEqual(
-      col.where(sort: Sort.desc).valueEqualTo(2).idProperty(),
+      col.where(sort: Sort.desc).filter().valueEqualTo(2).idProperty(),
+      [2],
+    );
+
+    await qEqual(
+      col.where(sort: Sort.desc).offset(1).limit(1).idProperty(),
+      [2],
+    );
+
+    await qEqual(
+      col
+          .where(sort: Sort.desc)
+          .filter()
+          .valueBetween(1, 3, includeLower: false, includeUpper: false)
+          .idProperty(),
       [2],
     );
   });

--- a/packages/isar_test/test/regression/issue_843_sort_test.dart
+++ b/packages/isar_test/test/regression/issue_843_sort_test.dart
@@ -25,6 +25,9 @@ void main() {
       ]);
     });
 
+    // Ascending sort should remain untouched.
+    await qEqual(col.where(sort: Sort.asc).idProperty(), [1, 2, 3]);
+
     await qEqual(col.where(sort: Sort.desc).idProperty(), [3, 2, 1]);
 
     await qEqual(
@@ -34,6 +37,22 @@ void main() {
           .valueGreaterThan(1)
           .idProperty(),
       [3, 2],
+    );
+
+    // Explicit where clauses must behave the same as before the fallback logic.
+    await qEqual(
+      col.where(sort: Sort.desc).idGreaterThan(1).idProperty(),
+      [3, 2],
+    );
+
+    await qEqual(
+      col.where(sort: Sort.asc).idGreaterThan(1).idProperty(),
+      [2, 3],
+    );
+
+    await qEqual(
+      col.where(sort: Sort.desc).valueEqualTo(2).idProperty(),
+      [2],
     );
   });
 }

--- a/packages/isar_test/test/regression/issue_843_sort_test.dart
+++ b/packages/isar_test/test/regression/issue_843_sort_test.dart
@@ -1,0 +1,39 @@
+import 'package:isar_community/isar.dart';
+import 'package:isar_test/isar_test.dart';
+
+part 'issue_843_sort_test.g.dart';
+
+@collection
+class Issue843Model {
+  Issue843Model({required this.id, required this.value});
+
+  Id id;
+
+  int value;
+}
+
+void main() {
+  isarTest('where(sort: desc) works without explicit where clause', () async {
+    final isar = await openTempIsar([Issue843ModelSchema]);
+    final col = isar.issue843Models;
+
+    await isar.tWriteTxn(() async {
+      await col.tPutAll([
+        Issue843Model(id: 1, value: 1),
+        Issue843Model(id: 3, value: 3),
+        Issue843Model(id: 2, value: 2),
+      ]);
+    });
+
+    await qEqual(col.where(sort: Sort.desc).idProperty(), [3, 2, 1]);
+
+    await qEqual(
+      col
+          .where(sort: Sort.desc)
+          .filter()
+          .valueGreaterThan(1)
+          .idProperty(),
+      [3, 2],
+    );
+  });
+}


### PR DESCRIPTION
Fix: When build() sees Sort.desc and there are no explicit where clauses, it now injects `IdWhereClause.any()` (the exact clause `.anyId()` would have added)

Example:

```
// Before (needed workaround)
final rows = await col.where(sort: Sort.desc).anyId().findAll(); // [3,2,1]

// After (no workaround)
final rows = await col.where(sort: Sort.desc).findAll();         // [3,2,1]
```