### PR TITLE
Fix generic getter handling to ensure ignored fields are properly excluded

### DIFF
--- a/.github/workflows/test_manual.yaml
+++ b/.github/workflows/test_manual.yaml
@@ -1,0 +1,38 @@
+name: Dart - manual generator tests with version input
+
+env:
+  FLUTTER_OVERRIDE: ${{ github.event.inputs.flutter_version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      flutter_version:
+        description: "Flutter Version"
+        required: true
+        default: "3.38.7"
+
+jobs:
+  version:
+    name: Version Display
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_OVERRIDE || vars.FLUTTER_VERSION }}
+      - run: flutter --version
+
+  test_generator:
+    name: Generator Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_OVERRIDE || vars.FLUTTER_VERSION }}
+      - name: Run Generator Unit tests
+        run: |
+          dart pub get
+          dart test
+        working-directory: packages/isar_community_generator

--- a/packages/isar_community_generator/lib/src/helper.dart
+++ b/packages/isar_community_generator/lib/src/helper.dart
@@ -38,11 +38,18 @@ extension ClassElementX on ClassElement {
         ],
     ]
         .where(
-          (PropertyInducingElement e) =>
-              e.isPublic &&
-              !e.isStatic &&
-              !_ignoreChecker.hasAnnotationOf(e.nonSynthetic) &&
-              !ignoreFields.contains(e.name),
+          (PropertyInducingElement e) {
+            if (!e.isPublic ||
+                e.isStatic ||
+                ignoreFields.contains(e.name) ||
+                _ignoreChecker.hasAnnotationOf(e.nonSynthetic) ||
+                (e.isSynthetic &&
+                    e.getter != null &&
+                    _ignoreChecker.hasAnnotationOf(e.getter!))) {
+              return false;
+            }
+            return true;
+          },
         )
         .distinctBy((e) => e.name)
         .toList();

--- a/packages/isar_community_generator/lib/src/helper.dart
+++ b/packages/isar_community_generator/lib/src/helper.dart
@@ -39,11 +39,18 @@ extension ClassElementX on ClassElement {
             ],
         ]
         .where(
-          (PropertyInducingElement e) =>
-              e.isPublic &&
-              !e.isStatic &&
-              !_ignoreChecker.hasAnnotationOf(e.nonSynthetic) &&
-              !ignoreFields.contains(e.name),
+          (PropertyInducingElement e) {
+            if (!e.isPublic ||
+                e.isStatic ||
+                ignoreFields.contains(e.name) ||
+                _ignoreChecker.hasAnnotationOf(e.nonSynthetic) ||
+                (e.isSynthetic &&
+                    e.getter != null &&
+                    _ignoreChecker.hasAnnotationOf(e.getter!))) {
+              return false;
+            }
+            return true;
+          },
         )
         .distinctBy((e) => e.name)
         .toList();

--- a/packages/isar_community_generator/lib/src/helper.dart
+++ b/packages/isar_community_generator/lib/src/helper.dart
@@ -44,7 +44,7 @@ extension ClassElementX on ClassElement {
                 e.isStatic ||
                 ignoreFields.contains(e.name) ||
                 _ignoreChecker.hasAnnotationOf(e.nonSynthetic) ||
-                (e.isSynthetic &&
+                (e.nonSynthetic != e &&
                     e.getter != null &&
                     _ignoreChecker.hasAnnotationOf(e.getter!))) {
               return false;

--- a/packages/isar_community_generator/test/success/collection_supertype_generic.dart
+++ b/packages/isar_community_generator/test/success/collection_supertype_generic.dart
@@ -7,7 +7,6 @@ abstract class MyAbstractClass<T> {
 
 @collection
 class Model<T> extends MyAbstractClass<T> {
-  @override
   Id? id;
 
   @override

--- a/packages/isar_community_generator/test/success/collection_supertype_generic.dart
+++ b/packages/isar_community_generator/test/success/collection_supertype_generic.dart
@@ -1,0 +1,16 @@
+import 'package:isar_community/isar.dart';
+
+abstract class MyAbstractClass<T> {
+  @ignore
+  T get object;
+}
+
+@collection
+class Model<T> extends MyAbstractClass<T> {
+  @override
+  Id? id;
+
+  @override
+  @ignore
+  T get object => 'example' as T;
+}

--- a/packages/isar_community_generator/test/success/ignore_member.dart
+++ b/packages/isar_community_generator/test/success/ignore_member.dart
@@ -1,0 +1,13 @@
+import 'package:isar_community/isar.dart';
+
+@collection
+class MyObject {
+  const MyObject({required this.isarId});
+
+  @ignore
+  MyUnknownClass get object => MyUnknownClass();
+
+  final Id? isarId;
+}
+
+class MyUnknownClass {}

--- a/packages/isar_community_generator/test/success_test.dart
+++ b/packages/isar_community_generator/test/success_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:isar_community_generator/isar_generator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Success case', () {
+    for (final file in Directory('test/success').listSync(recursive: true)) {
+      if (file is! File || !file.path.endsWith('.dart')) continue;
+
+      test(file.path, () async {
+        final content = await file.readAsLines();
+
+        final readerWriter = TestReaderWriter(
+          rootPackage: 'isar_community_generator',
+        );
+        await readerWriter.testing.loadIsolateSources();
+
+        final result = await testBuilder(
+          getIsarGenerator(BuilderOptions.empty),
+          {'a|${file.path}': content.join('\n')},
+          readerWriter: readerWriter,
+        );
+
+        expect(result.errors, isEmpty);
+      });
+    }
+  });
+}


### PR DESCRIPTION
The generator threw an exception about an unsupported type, if you had a generic getter in the base class, even if it was annotated with "@ignore". 

```
E Unsupported type. Please annotate the property with @ignore.                                                                                                                                                                                                      
  package:isar_analyzer/change_tracker.dart:18:11                                                                                                                                                                                                                   
     ╷                                                                                                                                                                                                                                                              
  18 │   Tid get id;                                                                                                                                                                                                                                                
     │           ^^ 
```

The issue was that when a getter is annotated with @ignore, the check !_ignoreChecker.hasAnnotationOf(e.nonSynthetic) did not work correctly because e is the variable (PropertyInducingElement), but the annotation might be on the getter accessor itself, not on the variable.

The issue was **introduced with Version 3.3.0** (probably with a new behaviour of the analyzer package).

- Fixed the issue
- Introduced "positive" tests, that make sure no exception is thrown.
- Introduced a manual github action to execute the generator tests with any flutter version.