### PR TITLE
fix: resolve memory leak caused by unreleased native resources

### DIFF
--- a/packages/isar_community/lib/src/native/isar_impl.dart
+++ b/packages/isar_community/lib/src/native/isar_impl.dart
@@ -12,13 +12,13 @@ import 'package:isar_community/src/native/isar_core.dart';
 import 'package:isar_community/src/native/txn.dart';
 
 class IsarImpl extends IsarCommon implements Finalizable {
+  static final _finalizer = NativeFinalizer(isarClose);
+
   IsarImpl(super.name, this.ptr) {
-    _finalizer = NativeFinalizer(isarClose);
     _finalizer.attach(this, ptr.cast(), detach: this);
   }
 
   final Pointer<CIsarInstance> ptr;
-  late final NativeFinalizer _finalizer;
 
   final offsets = <Type, List<int>>{};
 

--- a/packages/isar_community/lib/src/native/query_impl.dart
+++ b/packages/isar_community/lib/src/native/query_impl.dart
@@ -15,8 +15,10 @@ import 'package:isar_community/src/native/txn.dart';
 typedef QueryDeserialize<T> = List<T> Function(CObjectSet);
 
 class QueryImpl<T> extends Query<T> implements Finalizable {
+  static final _finalizer = NativeFinalizer(isarQueryFree);
+
   QueryImpl(this.col, this.queryPtr, this.deserialize, this.propertyId) {
-    NativeFinalizer(isarQueryFree).attach(this, queryPtr.cast());
+    _finalizer.attach(this, queryPtr.cast());
   }
   static const int maxLimit = 4294967295;
 


### PR DESCRIPTION
## Problem

Native query resources allocated by Isar were not being released properly, leading to a memory leak. Also described in an issue at the original isar project: https://github.com/isar/isar/issues/1641

The `NativeFinalizer` responsible for cleaning up the native part of `QueryImpl` gets disposed by the GC before the native free function is called. This leads to leaked native `Query` instances.

## Fix

Holding a static final reference to the `NativeFinalizer` (as shown in the example from the docs: https://api.dart.dev/dart-ffi/NativeFinalizer-class.html) so that it does not get disposed and can actually call the native `isar_q_free` function as intended.

## Testing

I verified this fix by profiling a query intensive task on an android device (Google Pixel 9, Android 16).
Before the fix:
<img width="1447" height="722" alt="Pasted image 20260218195556" src="https://github.com/user-attachments/assets/38e443dc-1441-4490-9575-bef74f087729" />

After the fix:
<img width="1451" height="727" alt="Pasted image 20260218195201" src="https://github.com/user-attachments/assets/383ee9a0-7ce6-4262-bd82-abd2b55245ff" />
