### PR TITLE
fix(inspector): fetch and display correct schema for multiple database instances

### DIFF
--- a/packages/isar_community/lib/src/isar_connect.dart
+++ b/packages/isar_community/lib/src/isar_connect.dart
@@ -4,8 +4,11 @@
 part of isar;
 
 abstract class _IsarConnect {
-  static const Map<ConnectAction,
-      Future<dynamic> Function(Map<String, dynamic> _)> _handlers = {
+  static const Map<
+    ConnectAction,
+    Future<dynamic> Function(Map<String, dynamic> _)
+  >
+  _handlers = {
     ConnectAction.getSchema: _getSchema,
     ConnectAction.listInstances: _listInstances,
     ConnectAction.watchInstance: _watchInstance,
@@ -94,7 +97,13 @@ abstract class _IsarConnect {
     });
   }
 
-  static Future<dynamic> _getSchema(Map<String, dynamic> _) async {
+  static Future<dynamic> _getSchema(Map<String, dynamic> params) async {
+    if (params.containsKey('instance')) {
+      final isar = Isar.getInstance(params['instance'] as String);
+      if (isar != null) {
+        return isar._collections.values.map((e) => e.schema.toJson()).toList();
+      }
+    }
     return _schemas!.map((e) => e.toJson()).toList();
   }
 
@@ -154,8 +163,11 @@ abstract class _IsarConnect {
     final cQuery = ConnectQuery.fromJson(params);
     final instance = Isar.getInstance(cQuery.instance)!;
 
-    final links =
-        _schemas!.firstWhere((e) => e.name == cQuery.collection).links.values;
+    final links = instance
+        .getCollectionByNameInternal(cQuery.collection)!
+        .schema
+        .links
+        .values;
 
     final query = cQuery.toQuery();
     params.remove('limit');
@@ -185,16 +197,18 @@ abstract class _IsarConnect {
       for (final object in objects) {
         for (final link in links) {
           final target = instance.getCollectionByNameInternal(link.target)!;
-          final links = await target.buildQuery<dynamic>(
-            whereClauses: [
-              LinkWhereClause(
-                linkCollection: source.name,
-                linkName: link.name,
-                id: object[source.schema.idName] as int,
-              ),
-            ],
-            limit: link.single ? 1 : null,
-          ).exportJson();
+          final links = await target
+              .buildQuery<dynamic>(
+                whereClauses: [
+                  LinkWhereClause(
+                    linkCollection: source.name,
+                    linkName: link.name,
+                    id: object[source.schema.idName] as int,
+                  ),
+                ],
+                limit: link.single ? 1 : null,
+              )
+              .exportJson();
 
           if (link.single) {
             object[link.name] = links.isEmpty ? null : links.first;

--- a/packages/isar_community_inspector/lib/connect_client.dart
+++ b/packages/isar_community_inspector/lib/connect_client.dart
@@ -86,8 +86,11 @@ class ConnectClient {
     return response.json?['result'] as T;
   }
 
-  Future<List<CollectionSchema<dynamic>>> getSchema() async {
-    final schema = await _call<List<dynamic>>(ConnectAction.getSchema);
+  Future<List<CollectionSchema<dynamic>>> getSchema(String instance) async {
+    final schema = await _call<List<dynamic>>(
+      ConnectAction.getSchema,
+      args: {'instance': instance},
+    );
     return schema
         .map(
           (e) => CollectionSchema<dynamic>.fromJson(e as Map<String, dynamic>),

--- a/packages/isar_community_inspector/lib/connected_layout.dart
+++ b/packages/isar_community_inspector/lib/connected_layout.dart
@@ -11,12 +11,12 @@ class ConnectedLayout extends StatefulWidget {
     super.key,
     required this.client,
     required this.instances,
-    required this.collections,
+    required this.schemasMap,
   });
 
   final ConnectClient client;
   final List<String> instances;
-  final List<CollectionSchema<dynamic>> collections;
+  final Map<String, List<CollectionSchema<dynamic>>> schemasMap;
 
   @override
   State<ConnectedLayout> createState() => _ConnectedLayoutState();
@@ -24,14 +24,16 @@ class ConnectedLayout extends StatefulWidget {
 
 class _ConnectedLayoutState extends State<ConnectedLayout> {
   late String selectedInstance;
-  late String selectedCollection = widget.collections.first.name;
+  late String selectedCollection;
   late StreamSubscription<void> infoSubscription;
 
   @override
   void initState() {
     _selectInstance(widget.instances.first);
     infoSubscription = widget.client.collectionInfoChanged.listen((_) {
-      setState(() {});
+      if (mounted) {
+        setState(() {});
+      }
     });
     super.initState();
   }
@@ -52,11 +54,17 @@ class _ConnectedLayoutState extends State<ConnectedLayout> {
 
   void _selectInstance(String instance) {
     selectedInstance = instance;
+    final schemas = widget.schemasMap[instance];
+    selectedCollection = schemas != null && schemas.isNotEmpty
+        ? schemas.first.name
+        : '';
     widget.client.watchInstance(instance);
   }
 
   @override
   Widget build(BuildContext context) {
+    final currentSchemas =
+        widget.schemasMap[selectedInstance] ?? <CollectionSchema<dynamic>>[];
     return Padding(
       padding: const EdgeInsets.all(25),
       child: Row(
@@ -72,7 +80,7 @@ class _ConnectedLayoutState extends State<ConnectedLayout> {
                   _selectInstance(instance);
                 });
               },
-              collections: widget.collections,
+              collections: currentSchemas,
               collectionInfo: widget.client.collectionInfo,
               selectedCollection: selectedCollection,
               onCollectionSelected: (collection) {
@@ -90,7 +98,7 @@ class _ConnectedLayoutState extends State<ConnectedLayout> {
               collection: selectedCollection,
               client: widget.client,
               schemas: {
-                for (final schema in widget.collections) ...{
+                for (final schema in currentSchemas) ...{
                   schema.name: schema,
                   for (final embedded in schema.embeddedSchemas.values) ...{
                     embedded.name: embedded,

--- a/packages/isar_community_inspector/lib/connection_screen.dart
+++ b/packages/isar_community_inspector/lib/connection_screen.dart
@@ -61,26 +61,37 @@ class _SchemaLoader extends StatefulWidget {
 
 class _SchemaLoaderState extends State<_SchemaLoader> {
   late Future<List<String>> instancesFuture;
-  late Future<List<CollectionSchema<dynamic>>> collectionsFuture;
+  late Future<Map<String, List<CollectionSchema<dynamic>>>> schemasFuture;
   late StreamSubscription<void> _instancesSubscription;
 
   @override
   void initState() {
-    instancesFuture = widget.client.listInstances();
-    collectionsFuture = widget.client.getSchema();
-    _instancesSubscription = widget.client.instancesChanged.listen((event) {
-      setState(() {
-        instancesFuture = widget.client.listInstances();
-      });
-    });
     super.initState();
+    _loadData();
+    _instancesSubscription = widget.client.instancesChanged.listen((event) {
+      if (mounted) {
+        setState(() {
+          _loadData();
+        });
+      }
+    });
+  }
+
+  void _loadData() {
+    instancesFuture = widget.client.listInstances();
+    schemasFuture = instancesFuture.then((instances) async {
+      final map = <String, List<CollectionSchema<dynamic>>>{};
+      for (final instance in instances) {
+        map[instance] = await widget.client.getSchema(instance);
+      }
+      return map;
+    });
   }
 
   @override
   void didUpdateWidget(covariant _SchemaLoader oldWidget) {
-    instancesFuture = widget.client.listInstances();
-    collectionsFuture = widget.client.getSchema();
     super.didUpdateWidget(oldWidget);
+    _loadData();
   }
 
   @override
@@ -92,13 +103,15 @@ class _SchemaLoaderState extends State<_SchemaLoader> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<List<dynamic>>(
-      future: Future.wait([instancesFuture, collectionsFuture]),
+      future: Future.wait([instancesFuture, schemasFuture]),
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           return ConnectedLayout(
             client: widget.client,
             instances: snapshot.data![0] as List<String>,
-            collections: snapshot.data![1] as List<CollectionSchema<dynamic>>,
+            schemasMap:
+                snapshot.data![1]
+                    as Map<String, List<CollectionSchema<dynamic>>>,
           );
         } else if (snapshot.hasError) {
           return const ErrorScreen();


### PR DESCRIPTION
## Description

Fixes #103

This PR addresses the bug where the Isar Inspector only displays the schema for the first opened database instance, regardless of which instance is selected in the UI.

### Changes Made:

**`isar_community` package:**
- Modified `_getSchema` in `isar_connect.dart` to extract the `instance` from RPC `params`. It now uses `Isar.getInstance(instance)._collections.values` to return the specific instance's schema instead of the globally cached `_schemas`.
- Updated `_executeQuery` in `isar_connect.dart` to retrieve `links` from the specific instance's schema (`instance.getCollectionByNameInternal(cQuery.collection)!.schema.links.values`) rather than global schemas.

**`isar_community_inspector` package:**
- Added a `String instance` parameter to `ConnectClient.getSchema()` and passed it in the RPC request args.
- Refactored `_SchemaLoaderState` inside `connection_screen.dart` to iterate over all instances returned by `listInstances()` and fetch schemas for *each* instance into a `Map<String, List<CollectionSchema<dynamic>>>`.
- Updated `ConnectedLayout` and its state to accept this `schemasMap` and dynamically load the correct schema list corresponding to the active `selectedInstance`.

### Testing
- Validated via a local example app testing up to 3 distinct `Isar.openSync` instances across different screens.
- The example repository demonstrating this fix is available at: https://github.com/dhruvanbhalara/isar_multiple_db_example
- The inspector successfully switches schemas when selecting different dropdown instances.
- Core packages were validated via `dart analyze` and no regressions were detected.
