### PR TITLE
upgrade packages on version 3.3.0 with lint tweaks

### DIFF
--- a/packages/isar_community/pubspec.yaml
+++ b/packages/isar_community/pubspec.yaml
@@ -21,9 +21,9 @@ platforms:
 dependencies:
   ffi: ">=2.0.0 <3.0.0"
   js: any
-  meta: ^1.7.0
+  meta: ^1.16.0
 
 dev_dependencies:
-  ffigen: ^19.0.0
+  ffigen: ^20.1.1
   test: any
-  very_good_analysis: ^3.0.1
+  very_good_analysis: ^10.0.0

--- a/packages/isar_community_generator/pubspec.yaml
+++ b/packages/isar_community_generator/pubspec.yaml
@@ -19,7 +19,7 @@ platforms:
   windows:
 
 dependencies:
-  analyzer: ">=7.4.5 <9.0.0"
+  analyzer: ">=7.4.5 <11.0.0"
   build: ^4.0.0
   dart_style: ^3.0.1
   dartx: ^1.1.0

--- a/packages/isar_community_inspector/lib/collection/button_prev_next.dart
+++ b/packages/isar_community_inspector/lib/collection/button_prev_next.dart
@@ -3,10 +3,10 @@ import 'package:isar_community_inspector/collection/collection_area.dart';
 
 class PrevNextButtons extends StatelessWidget {
   const PrevNextButtons({
-    super.key,
     required this.page,
     required this.count,
     required this.onChanged,
+    super.key,
   });
 
   final int page;

--- a/packages/isar_community_inspector/lib/collection/button_sort.dart
+++ b/packages/isar_community_inspector/lib/collection/button_sort.dart
@@ -3,11 +3,11 @@ import 'package:isar_community/isar.dart';
 
 class SortButtons extends StatelessWidget {
   const SortButtons({
-    super.key,
     required this.properties,
     required this.property,
     required this.asc,
     required this.onChanged,
+    super.key,
   });
 
   final List<PropertySchema> properties;

--- a/packages/isar_community_inspector/lib/collection/collection_area.dart
+++ b/packages/isar_community_inspector/lib/collection/collection_area.dart
@@ -21,11 +21,11 @@ const objectsPerPage = 20;
 
 class CollectionArea extends StatefulWidget {
   const CollectionArea({
-    super.key,
     required this.instance,
     required this.collection,
     required this.schemas,
     required this.client,
+    super.key,
   });
 
   final String instance;
@@ -46,7 +46,7 @@ class _CollectionAreaState extends State<CollectionArea> {
 
   var page = 0;
   var filter = const FilterGroup.and([]);
-  late var sortProperty = widget.collectionSchema.idName;
+  late String sortProperty = widget.collectionSchema.idName;
   var sortAsc = true;
   var objects = <IsarObject>[];
   var objectsCount = 0;

--- a/packages/isar_community_inspector/lib/collection/objects_list_sliver.dart
+++ b/packages/isar_community_inspector/lib/collection/objects_list_sliver.dart
@@ -8,13 +8,13 @@ import 'package:isar_community_inspector/object/object_view.dart';
 
 class ObjectsListSliver extends StatelessWidget {
   const ObjectsListSliver({
-    super.key,
     required this.instance,
     required this.collection,
     required this.schemas,
     required this.objects,
     required this.onUpdate,
     required this.onDelete,
+    super.key,
   });
 
   final String instance;
@@ -31,8 +31,8 @@ class ObjectsListSliver extends StatelessWidget {
     final collectionSchema = schemas[collection]! as CollectionSchema;
     return SliverList(
       delegate: SliverChildBuilderDelegate(childCount: objects.length, (
-        BuildContext context,
-        int index,
+        context,
+        index,
       ) {
         final object = objects[index];
         return Card(

--- a/packages/isar_community_inspector/lib/collections_list.dart
+++ b/packages/isar_community_inspector/lib/collections_list.dart
@@ -6,11 +6,11 @@ import 'package:isar_community_inspector/connect_client.dart';
 
 class CollectionsList extends StatelessWidget {
   const CollectionsList({
-    super.key,
     required this.collections,
     required this.collectionInfo,
     required this.selectedCollection,
     required this.onSelected,
+    super.key,
   });
 
   final List<CollectionSchema<dynamic>> collections;
@@ -24,7 +24,7 @@ class CollectionsList extends StatelessWidget {
 
     return ListView.builder(
       primary: false,
-      itemBuilder: (BuildContext context, int index) {
+      itemBuilder: (context, index) {
         final collection = collections[index];
         final info = collectionInfo[collection.name];
 

--- a/packages/isar_community_inspector/lib/connect_client.dart
+++ b/packages/isar_community_inspector/lib/connect_client.dart
@@ -60,7 +60,7 @@ class ConnectClient {
         client._queryChangedController.add(null);
       },
     };
-    service.onExtensionEvent.listen((Event event) {
+    service.onExtensionEvent.listen((event) {
       final data = event.extensionData?.data ?? {};
       handlers[event.extensionKind]?.call(data);
     });

--- a/packages/isar_community_inspector/lib/connected_layout.dart
+++ b/packages/isar_community_inspector/lib/connected_layout.dart
@@ -8,10 +8,10 @@ import 'package:isar_community_inspector/sidebar.dart';
 
 class ConnectedLayout extends StatefulWidget {
   const ConnectedLayout({
-    super.key,
     required this.client,
     required this.instances,
     required this.collections,
+    super.key,
   });
 
   final ConnectClient client;

--- a/packages/isar_community_inspector/lib/connection_screen.dart
+++ b/packages/isar_community_inspector/lib/connection_screen.dart
@@ -7,7 +7,7 @@ import 'package:isar_community_inspector/connected_layout.dart';
 import 'package:isar_community_inspector/error_screen.dart';
 
 class ConnectionScreen extends StatefulWidget {
-  const ConnectionScreen({super.key, required this.port, required this.secret});
+  const ConnectionScreen({required this.port, required this.secret, super.key});
 
   final String port;
   final String secret;

--- a/packages/isar_community_inspector/lib/instance_selector.dart
+++ b/packages/isar_community_inspector/lib/instance_selector.dart
@@ -3,10 +3,10 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class InstanceSelector extends StatefulWidget {
   const InstanceSelector({
-    super.key,
     required this.instances,
     required this.selectedInstance,
     required this.onSelected,
+    super.key,
   });
 
   final List<String> instances;
@@ -31,7 +31,7 @@ class _InstanceSelectorState extends State<InstanceSelector>
 
   @override
   void initState() {
-    _animation.addStatusListener((AnimationStatus status) {
+    _animation.addStatusListener((status) {
       setState(() {});
     });
     super.initState();
@@ -100,9 +100,9 @@ class _InstanceSelectorState extends State<InstanceSelector>
 
 class InstanceButton extends StatelessWidget {
   const InstanceButton({
-    super.key,
     required this.instance,
     required this.onTap,
+    super.key,
   });
 
   final String instance;
@@ -140,11 +140,11 @@ class InstanceButton extends StatelessWidget {
 
 class SelectedInstanceButton extends StatelessWidget {
   const SelectedInstanceButton({
-    super.key,
     required this.instance,
     required this.onTap,
     required this.hasMultiple,
     required this.color,
+    super.key,
   });
 
   final String instance;

--- a/packages/isar_community_inspector/lib/main.dart
+++ b/packages/isar_community_inspector/lib/main.dart
@@ -1,14 +1,15 @@
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html';
+// ignore_for_file: lines_longer_than_80_chars
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:isar_community_inspector/connection_screen.dart';
+import 'package:web/web.dart' as web;
 
 void main() async {
   if (['chrome', 'firefox'].any(
-    (userAgent) => window.navigator.userAgent.toLowerCase().contains(userAgent),
+    (userAgent) =>
+        web.window.navigator.userAgent.toLowerCase().contains(userAgent),
   )) {
     runApp(DarkMode(notifier: DarkModeNotifier(), child: const App()));
   } else {
@@ -47,7 +48,7 @@ final _router = GoRouter(
   routes: <GoRoute>[
     GoRoute(
       path: '/',
-      builder: (BuildContext context, GoRouterState state) {
+      builder: (context, state) {
         return const Material(
           child: Center(
             child: Text(
@@ -62,7 +63,7 @@ final _router = GoRouter(
     ),
     GoRoute(
       path: '/:port/:secret',
-      builder: (BuildContext context, GoRouterState state) {
+      builder: (context, state) {
         return GestureDetector(
           onTap: () {
             FocusScope.of(context).requestFocus(FocusNode());
@@ -70,8 +71,8 @@ final _router = GoRouter(
           child: Scaffold(
             body: Material(
               child: ConnectionScreen(
-                port: state.params['port']!,
-                secret: state.params['secret']!,
+                port: state.pathParameters['port']!,
+                secret: state.pathParameters['secret']!,
               ),
             ),
           ),
@@ -105,7 +106,7 @@ class App extends StatelessWidget {
 }
 
 class DarkMode extends InheritedNotifier<DarkModeNotifier> {
-  const DarkMode({super.key, super.notifier, required super.child});
+  const DarkMode({required super.child, super.key, super.notifier});
 
   static DarkModeNotifier of(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<DarkMode>()!.notifier!;

--- a/packages/isar_community_inspector/lib/object/object_view.dart
+++ b/packages/isar_community_inspector/lib/object/object_view.dart
@@ -7,12 +7,12 @@ import 'package:isar_community_inspector/object/property_view.dart';
 
 class ObjectView extends StatelessWidget {
   const ObjectView({
-    super.key,
-    this.root = false,
     required this.schemaName,
     required this.schemas,
     required this.object,
     required this.onUpdate,
+    super.key,
+    this.root = false,
   });
 
   final bool root;

--- a/packages/isar_community_inspector/lib/object/property_builder.dart
+++ b/packages/isar_community_inspector/lib/object/property_builder.dart
@@ -3,11 +3,11 @@ import 'package:google_fonts/google_fonts.dart';
 
 class PropertyBuilder extends StatefulWidget {
   const PropertyBuilder({
-    super.key,
     required this.property,
+    required this.type,
+    super.key,
     this.underline = false,
     this.value,
-    required this.type,
     this.children = const [],
   });
 

--- a/packages/isar_community_inspector/lib/object/property_embedded_view.dart
+++ b/packages/isar_community_inspector/lib/object/property_embedded_view.dart
@@ -7,11 +7,11 @@ import 'package:isar_community_inspector/object/property_value.dart';
 
 class EmbeddedPropertyView extends StatelessWidget {
   const EmbeddedPropertyView({
-    super.key,
     required this.property,
     required this.schemas,
     required this.object,
     required this.onUpdate,
+    super.key,
   });
 
   final PropertySchema property;

--- a/packages/isar_community_inspector/lib/object/property_link_view.dart
+++ b/packages/isar_community_inspector/lib/object/property_link_view.dart
@@ -7,11 +7,11 @@ import 'package:isar_community_inspector/object/property_value.dart';
 
 class LinkPropertyView extends StatelessWidget {
   const LinkPropertyView({
-    super.key,
     required this.link,
     required this.schemas,
     required this.object,
     required this.onUpdate,
+    super.key,
   });
 
   final LinkSchema link;

--- a/packages/isar_community_inspector/lib/object/property_value.dart
+++ b/packages/isar_community_inspector/lib/object/property_value.dart
@@ -5,9 +5,9 @@ import 'package:isar_community/isar.dart';
 class PropertyValue extends StatelessWidget {
   const PropertyValue(
     this.value, {
-    super.key,
     required this.enumMap,
     required this.type,
+    super.key,
     this.onUpdate,
   });
 
@@ -34,7 +34,7 @@ class PropertyValue extends StatelessWidget {
       return GestureDetector(
         onTapDown: onUpdate == null
             ? null
-            : (TapDownDetails details) async {
+            : (details) async {
                 final newValue = await showMenu(
                   context: context,
                   position: RelativeRect.fromLTRB(
@@ -71,7 +71,7 @@ class PropertyValue extends StatelessWidget {
         return GestureDetector(
           onTapDown: onUpdate == null
               ? null
-              : (TapDownDetails details) async {
+              : (details) async {
                   final newValue = await showMenu(
                     context: context,
                     position: RelativeRect.fromLTRB(

--- a/packages/isar_community_inspector/lib/object/property_view.dart
+++ b/packages/isar_community_inspector/lib/object/property_view.dart
@@ -5,12 +5,12 @@ import 'package:isar_community_inspector/object/property_value.dart';
 
 class PropertyView extends StatelessWidget {
   const PropertyView({
-    super.key,
     required this.property,
     required this.value,
     required this.isId,
     required this.isIndexed,
     required this.onUpdate,
+    super.key,
   });
 
   final PropertySchema property;

--- a/packages/isar_community_inspector/lib/query_builder/query_filter.dart
+++ b/packages/isar_community_inspector/lib/query_builder/query_filter.dart
@@ -5,10 +5,10 @@ import 'package:isar_community_inspector/util.dart';
 
 class QueryFilter extends StatelessWidget {
   const QueryFilter({
-    super.key,
     required this.collection,
     required this.condition,
     required this.onChanged,
+    super.key,
   });
 
   final CollectionSchema<dynamic> collection;

--- a/packages/isar_community_inspector/lib/query_builder/query_group.dart
+++ b/packages/isar_community_inspector/lib/query_builder/query_group.dart
@@ -4,11 +4,11 @@ import 'package:isar_community_inspector/query_builder/query_filter.dart';
 
 class QueryGroup extends StatelessWidget {
   const QueryGroup({
-    super.key,
     required this.collection,
     required this.group,
     required this.level,
     required this.onChanged,
+    super.key,
     this.onDelete,
   });
 
@@ -196,11 +196,11 @@ class _Guideline extends StatelessWidget {
 
 class GroupFilterButton extends StatelessWidget {
   const GroupFilterButton({
-    super.key,
     required this.idName,
     required this.group,
     required this.level,
     required this.onAdd,
+    super.key,
   });
 
   final String idName;

--- a/packages/isar_community_inspector/lib/sidebar.dart
+++ b/packages/isar_community_inspector/lib/sidebar.dart
@@ -7,7 +7,6 @@ import 'package:isar_community_inspector/main.dart';
 
 class Sidebar extends StatelessWidget {
   const Sidebar({
-    super.key,
     required this.instances,
     required this.selectedInstance,
     required this.onInstanceSelected,
@@ -15,6 +14,7 @@ class Sidebar extends StatelessWidget {
     required this.collectionInfo,
     required this.selectedCollection,
     required this.onCollectionSelected,
+    super.key,
   });
 
   final List<String> instances;

--- a/packages/isar_community_inspector/pubspec.yaml
+++ b/packages/isar_community_inspector/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isar_community_inspector
 publish_to: "none"
-version: 1.0.0+1
+version: 1.0.1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -13,17 +13,18 @@ dependencies:
     sdk: flutter
   flutter_svg: any
   font_awesome_flutter: any
-  go_router: ^5.0.0
-  google_fonts: 6.1.0
+  go_router: ^17.0.0
+  google_fonts: 8.0.2
   isar_community:
     path: ../isar_community
-  vm_service: ^11.0.0
-  web_socket_channel: ^2.2.0
+  vm_service: ^15.0.2
+  web_socket_channel: ^3.0.3
+  web: 1.1.1
 
 dev_dependencies:
   build_runner: any
-  flutter_lints: ^2.0.1
-  very_good_analysis: ^3.0.1
+  flutter_lints: ^6.0.0
+  very_good_analysis: ^10.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/isar_test/lib/src/common.dart
+++ b/packages/isar_test/lib/src/common.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
-const kIsWeb = identical(0, 0.0);
+const bool kIsWeb = identical(0, 0.0);
 
 final testErrors = <String>[];
 int testCount = 0;

--- a/packages/isar_test/pubspec.yaml
+++ b/packages/isar_test/pubspec.yaml
@@ -17,9 +17,11 @@ dependencies:
     path: ../isar_community
   isar_community_flutter_libs:
     path: ../isar_community_flutter_libs
-  meta: ^1.8.0
+  meta: ^1.16.0
   path: ^1.8.2
   path_provider: ^2.0.10
+  test: ^1.30.0
+  test_api: ">=0.7.0 <0.8.0"
 
 dev_dependencies:
   build_runner: any
@@ -27,9 +29,7 @@ dev_dependencies:
     sdk: flutter
   isar_community_generator:
     path: ../isar_community_generator
-  test: ^1.26.3
-  test_api: ">=0.7.0 <0.8.0"
-  very_good_analysis: ^3.0.1
+  very_good_analysis: ^10.0.0
 
 
 dependency_overrides:


### PR DESCRIPTION
updated all of the packages to work in flutter 3.41.2 except the example folder.  There were a number of lint tweaks to isar_community_inspeactor