### PR TITLE
fix: address some pre-existing CI issues (lint, coverage dep)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,7 @@ jobs:
     name: Dart Test
     strategy:
       matrix:
-        os: [macos-14, macos-13, ubuntu-22.04, windows-2022]
+        os: [macos-14, ubuntu-22.04, windows-2022]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -148,6 +148,7 @@ jobs:
         run: |
           flutter pub add json_annotation
           flutter pub add intl
+          echo -e "\ndependency_overrides:\n  test_api: 0.7.7" >> pubspec.yaml
           flutter pub add isar_test --path ../isar_test
         working-directory: packages/isar_community
       - name: Collect isar Coverage

--- a/examples/pub/lib/models/asset.g.dart
+++ b/examples/pub/lib/models/asset.g.dart
@@ -62,7 +62,7 @@ const AssetSchema = CollectionSchema(
   getId: _assetGetId,
   getLinks: _assetGetLinks,
   attach: _assetAttach,
-  version: '3.2.0-dev.2',
+  version: '3.3.0',
 );
 
 int _assetEstimateSize(

--- a/examples/pub/lib/models/package.g.dart
+++ b/examples/pub/lib/models/package.g.dart
@@ -114,7 +114,7 @@ const PackageSchema = CollectionSchema(
   getId: _packageGetId,
   getLinks: _packageGetLinks,
   attach: _packageAttach,
-  version: '3.2.0-dev.2',
+  version: '3.3.0',
 );
 
 int _packageEstimateSize(

--- a/packages/isar_community/lib/src/query_builder_extensions.dart
+++ b/packages/isar_community/lib/src/query_builder_extensions.dart
@@ -170,7 +170,8 @@ extension QueryLimit<OBJ, R> on QueryBuilder<OBJ, R, QLimit> {
 /// @nodoc
 @protected
 typedef QueryOption<OBJ, S, RS> = QueryBuilder<OBJ, OBJ, RS> Function(
-    QueryBuilder<OBJ, OBJ, S> q);
+  QueryBuilder<OBJ, OBJ, S> q,
+);
 
 /// Extension for QueryBuilders.
 extension QueryModifier<OBJ, S> on QueryBuilder<OBJ, OBJ, S> {

--- a/packages/isar_community/lib/src/schema/collection_schema.dart
+++ b/packages/isar_community/lib/src/schema/collection_schema.dart
@@ -91,7 +91,7 @@ class CollectionSchema<OBJ> extends Schema<OBJ> {
   final String version;
 
   /// @nodoc
-  void toCollection(void Function<OBJ>() callback) => callback<OBJ>();
+  void toCollection(void Function<T>() callback) => callback<OBJ>();
 
   /// @nodoc
   @pragma('vm:prefer-inline')

--- a/packages/isar_community/lib/src/schema/schema.dart
+++ b/packages/isar_community/lib/src/schema/schema.dart
@@ -93,7 +93,10 @@ class Schema<OBJ> {
 /// @nodoc
 @protected
 typedef EstimateSize<T> = int Function(
-    T object, List<int> offsets, Map<Type, List<int>> allOffsets);
+  T object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+);
 
 /// @nodoc
 @protected

--- a/packages/isar_community_generator/lib/src/object_info.dart
+++ b/packages/isar_community_generator/lib/src/object_info.dart
@@ -171,7 +171,7 @@ class ObjectIndex {
   final bool unique;
   final bool replace;
 
-  late final id = xxh3(utf8.encode(name));
+  late final int id = xxh3(utf8.encode(name));
 }
 
 class ObjectLink {

--- a/packages/isar_test/integration_test/integration_test.dart
+++ b/packages/isar_test/integration_test/integration_test.dart
@@ -28,9 +28,13 @@ void main() async {
     tests.main();
   });
 
-  testWidgets('Isar', (t) async {
-    await completer.future;
-    expect(testCount > 0, true);
-    expect(testErrors, isEmpty);
-  }, timeout: Timeout.none);
+  testWidgets(
+    'Isar',
+    (t) async {
+      await completer.future;
+      expect(testCount > 0, true);
+      expect(testErrors, isEmpty);
+    },
+    timeout: Timeout.none,
+  );
 }

--- a/packages/isar_test/lib/src/common.dart
+++ b/packages/isar_test/lib/src/common.dart
@@ -70,16 +70,19 @@ void _isarTest(
   test(
     testName,
     () async {
-      await runZoned(() async {
-        try {
-          await _prepareTest();
-          await body();
-          testCount++;
-        } catch (e) {
-          testErrors.add('$testName: $e');
-          rethrow;
-        }
-      }, zoneValues: {#syncTest: syncTest});
+      await runZoned(
+        () async {
+          try {
+            await _prepareTest();
+            await body();
+            testCount++;
+          } catch (e) {
+            testErrors.add('$testName: $e');
+            rethrow;
+          }
+        },
+        zoneValues: {#syncTest: syncTest},
+      );
     },
     timeout: timeout ?? const Timeout(Duration(minutes: 10)),
     skip: skip,

--- a/packages/isar_test/lib/src/matchers.dart
+++ b/packages/isar_test/lib/src/matchers.dart
@@ -73,10 +73,13 @@ Matcher throwsIsarError([String? contains]) {
 
 Matcher get throwsAssertionError {
   var matcher = anything;
-  assert(() {
-    matcher = throwsA(isA<AssertionError>());
-    return true;
-  }(), 'only in debug mode');
+  assert(
+    () {
+      matcher = throwsA(isA<AssertionError>());
+      return true;
+    }(),
+    'only in debug mode',
+  );
   return matcher;
 }
 

--- a/packages/isar_test/pubspec.yaml
+++ b/packages/isar_test/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   meta: ^1.8.0
   path: ^1.8.2
   path_provider: ^2.0.10
+  test: ^1.26.3
+  test_api: ">=0.7.0 <0.8.0"
 
 dev_dependencies:
   build_runner: any
@@ -27,8 +29,6 @@ dev_dependencies:
     sdk: flutter
   isar_community_generator:
     path: ../isar_community_generator
-  test: ^1.26.3
-  test_api: ">=0.7.0 <0.8.0"
   very_good_analysis: ^3.0.1
 
 

--- a/packages/isar_test/test/default_value/default_test.dart
+++ b/packages/isar_test/test/default_value/default_test.dart
@@ -144,9 +144,12 @@ void main() {
       final isarName = isar1.name;
       await isar1.close();
 
-      final isar2 = await openTempIsar([
-        DefaultListModelSchema,
-      ], name: isarName);
+      final isar2 = await openTempIsar(
+        [
+          DefaultListModelSchema,
+        ],
+        name: isarName,
+      );
       final obj = (await isar2.defaultListModels.tGet(0))!;
       expect(obj.boolValue, [true, false]);
       expect(obj.byteValue, [1, 3]);
@@ -165,9 +168,12 @@ void main() {
       final isarName = isar1.name;
       await isar1.close();
 
-      final isar2 = await openTempIsar([
-        DefaultListModelSchema,
-      ], name: isarName);
+      final isar2 = await openTempIsar(
+        [
+          DefaultListModelSchema,
+        ],
+        name: isarName,
+      );
       expect(
         await isar2.defaultListModels.where().boolValueProperty().tFindFirst(),
         [true, false],

--- a/packages/isar_test/test/default_value/no_default_test.dart
+++ b/packages/isar_test/test/default_value/no_default_test.dart
@@ -174,9 +174,12 @@ void main() {
       final isarName = isar1.name;
       await isar1.close();
 
-      final isar2 = await openTempIsar([
-        NoDefaultListModelSchema,
-      ], name: isarName);
+      final isar2 = await openTempIsar(
+        [
+          NoDefaultListModelSchema,
+        ],
+        name: isarName,
+      );
       final obj = (await isar2.noDefaultListModels.tGet(0))!;
       expect(obj.boolValue, isEmpty);
       expect(obj.byteValue, isEmpty);
@@ -197,9 +200,12 @@ void main() {
       final isarName = isar1.name;
       await isar1.close();
 
-      final isar2 = await openTempIsar([
-        NoDefaultListModelSchema,
-      ], name: isarName);
+      final isar2 = await openTempIsar(
+        [
+          NoDefaultListModelSchema,
+        ],
+        name: isarName,
+      );
       expect(
         await isar2.noDefaultListModels
             .where()

--- a/packages/isar_test/test/default_value/nullable_test.dart
+++ b/packages/isar_test/test/default_value/nullable_test.dart
@@ -160,9 +160,12 @@ void main() {
       final isarName = isar1.name;
       await isar1.close();
 
-      final isar2 = await openTempIsar([
-        NullableListModelSchema,
-      ], name: isarName);
+      final isar2 = await openTempIsar(
+        [
+          NullableListModelSchema,
+        ],
+        name: isarName,
+      );
       final obj = (await isar2.nullableListModels.tGet(0))!;
       expect(obj.boolValue, null);
       expect(obj.shortValue, null);
@@ -182,9 +185,12 @@ void main() {
       final isarName = isar1.name;
       await isar1.close();
 
-      final isar2 = await openTempIsar([
-        NullableListModelSchema,
-      ], name: isarName);
+      final isar2 = await openTempIsar(
+        [
+          NullableListModelSchema,
+        ],
+        name: isarName,
+      );
       expect(
         await isar2.nullableListModels.where().boolValueProperty().tFindFirst(),
         null,

--- a/packages/isar_test/test/filter/filter_embedded_list_test.dart
+++ b/packages/isar_test/test/filter/filter_embedded_list_test.dart
@@ -710,21 +710,24 @@ void main() {
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a1 b1 - 1')),
+                (q) => q.nameEqualTo('embedded a1 b1 - 1'),
+              ),
             ),
         [obj1],
       );
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a1 b1 - 2')),
+                (q) => q.nameEqualTo('embedded a1 b1 - 2'),
+              ),
             ),
         [obj1],
       );
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a1 b1 - 3')),
+                (q) => q.nameEqualTo('embedded a1 b1 - 3'),
+              ),
             ),
         [obj1],
       );
@@ -732,7 +735,8 @@ void main() {
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a3 b3 - 1')),
+                (q) => q.nameEqualTo('embedded a3 b3 - 1'),
+              ),
             ),
         [obj3],
       );
@@ -740,35 +744,40 @@ void main() {
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a5 b5 - 1')),
+                (q) => q.nameEqualTo('embedded a5 b5 - 1'),
+              ),
             ),
         [obj5],
       );
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a5 b5 - 2')),
+                (q) => q.nameEqualTo('embedded a5 b5 - 2'),
+              ),
             ),
         [obj5],
       );
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a5 b5 - 3')),
+                (q) => q.nameEqualTo('embedded a5 b5 - 3'),
+              ),
             ),
         [obj5],
       );
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a5 b5 - 4')),
+                (q) => q.nameEqualTo('embedded a5 b5 - 4'),
+              ),
             ),
         [obj5],
       );
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a5 b5 - 5')),
+                (q) => q.nameEqualTo('embedded a5 b5 - 5'),
+              ),
             ),
         [obj5],
       );
@@ -776,7 +785,8 @@ void main() {
       await qEqualSet(
         isar.models.filter().embeddedAsElement(
               (q) => q.embeddedBsElement(
-                  (q) => q.nameEqualTo('embedded a6 b6 - 1')),
+                (q) => q.nameEqualTo('embedded a6 b6 - 1'),
+              ),
             ),
         [obj6],
       );

--- a/packages/isar_test/test/filter/link/filter_link_circular_indirect_test.dart
+++ b/packages/isar_test/test/filter/link/filter_link_circular_indirect_test.dart
@@ -228,7 +228,8 @@ void main() {
       await qEqualSet(
         isar.modelAs.filter().bLinks(
               (q) => q.cLinks(
-                  (q) => q.aLinks((q) => q.nameEqualTo('non existing'))),
+                (q) => q.aLinks((q) => q.nameEqualTo('non existing')),
+              ),
             ),
         [],
       );
@@ -287,7 +288,8 @@ void main() {
       await qEqualSet(
         isar.modelBs.filter().cLinks(
               (q) => q.aLinks(
-                  (q) => q.bLinks((q) => q.nameEqualTo('non existing'))),
+                (q) => q.bLinks((q) => q.nameEqualTo('non existing')),
+              ),
             ),
         [],
       );
@@ -346,7 +348,8 @@ void main() {
       await qEqualSet(
         isar.modelCs.filter().aLinks(
               (q) => q.bLinks(
-                  (q) => q.cLinks((q) => q.nameEqualTo('non existing'))),
+                (q) => q.cLinks((q) => q.nameEqualTo('non existing')),
+              ),
             ),
         [],
       );

--- a/packages/isar_test/test/migration/add_remove_collection_test.dart
+++ b/packages/isar_test/test/migration/add_remove_collection_test.dart
@@ -49,10 +49,13 @@ void main() {
     await isar1.model1s.verify([obj1A, obj1B]);
     expect(await isar1.close(), true);
 
-    final isar2 = await openTempIsar([
-      Model1Schema,
-      Model2Schema,
-    ], name: isar1.name);
+    final isar2 = await openTempIsar(
+      [
+        Model1Schema,
+        Model2Schema,
+      ],
+      name: isar1.name,
+    );
     await isar2.model1s.verify([obj1A, obj1B]);
     await isar2.model2s.verify([]);
     final obj2 = Model2(null, 'col2_a');
@@ -89,10 +92,13 @@ void main() {
     await isar2.model1s.verifyLink('link', [obj1A.id!], [obj1B.id!]);
     expect(await isar2.close(), true);
 
-    final isar3 = await openTempIsar([
-      Model1Schema,
-      Model2Schema,
-    ], name: isar1.name);
+    final isar3 = await openTempIsar(
+      [
+        Model1Schema,
+        Model2Schema,
+      ],
+      name: isar1.name,
+    );
     await isar3.model1s.verify([obj1A, obj1B]);
     await isar3.model1s.verifyLink('link', [obj1A.id!], [obj1B.id!]);
     await isar3.model2s.verify([]);

--- a/packages/isar_test/test/query/multi_filter_test.dart
+++ b/packages/isar_test/test/query/multi_filter_test.dart
@@ -51,39 +51,54 @@ void main() {
       });
 
       isarTest('one matching element', () async {
-        final q = isar.models.where().anyOf([
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.where().anyOf(
+          [
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model2]);
       });
 
       isarTest('two matching elements', () async {
-        final q = isar.models.where().anyOf([
-          0,
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.where().anyOf(
+          [
+            0,
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model0, model2]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.where().anyOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.where().anyOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
       });
 
       isarTest('one matching and one non-matching elements', () async {
-        final q = isar.models.where().anyOf([
-          7,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.where().anyOf(
+          [
+            7,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model3]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.where().anyOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.where().anyOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
       });
     });
@@ -104,66 +119,96 @@ void main() {
       });
 
       isarTest('one matching element', () async {
-        final q = isar.models.filter().anyOf([
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().anyOf(
+          [
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model2]);
 
-        final notQ = isar.models.filter().not().anyOf([
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().anyOf(
+          [
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model3]);
       });
 
       isarTest('two matching elements', () async {
-        final q = isar.models.filter().anyOf([
-          0,
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().anyOf(
+          [
+            0,
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model0, model2]);
 
-        final notQ = isar.models.filter().not().anyOf([
-          0,
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().anyOf(
+          [
+            0,
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model1, model3]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.filter().anyOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().anyOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
 
-        final notQ = isar.models.filter().not().anyOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().anyOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2, model3]);
       });
 
       isarTest('one matching and one non-matching elements', () async {
-        final q = isar.models.filter().anyOf([
-          7,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().anyOf(
+          [
+            7,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model3]);
 
-        final notQ = isar.models.filter().not().anyOf([
-          7,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().anyOf(
+          [
+            7,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.filter().anyOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().anyOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
 
-        final notQ = isar.models.filter().not().anyOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().anyOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2, model3]);
       });
     });
@@ -184,66 +229,96 @@ void main() {
       });
 
       isarTest('one matching element', () async {
-        final q = isar.models.filter().allOf([
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().allOf(
+          [
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model2]);
 
-        final notQ = isar.models.filter().not().allOf([
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().allOf(
+          [
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model3]);
       });
 
       isarTest('two matching elements', () async {
-        final q = isar.models.filter().allOf([
-          2,
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().allOf(
+          [
+            2,
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model2]);
 
-        final notQ = isar.models.filter().not().allOf([
-          2,
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().allOf(
+          [
+            2,
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model3]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.filter().allOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().allOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
 
-        final notQ = isar.models.filter().not().allOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().allOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2, model3]);
       });
 
       isarTest('one matching and one non-matching elements', () async {
-        final q = isar.models.filter().allOf([
-          7,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().allOf(
+          [
+            7,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
 
-        final notQ = isar.models.filter().not().allOf([
-          7,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().allOf(
+          [
+            7,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2, model3]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.filter().allOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().allOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
 
-        final notQ = isar.models.filter().not().allOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().allOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2, model3]);
       });
     });
@@ -264,68 +339,98 @@ void main() {
       });
 
       isarTest('one matching element', () async {
-        final q = isar.models.filter().oneOf([
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().oneOf(
+          [
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model2]);
 
-        final notQ = isar.models.filter().not().oneOf([
-          2,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().oneOf(
+          [
+            2,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model3]);
       });
 
       isarTest('two matching elements', () async {
-        final q = isar.models.filter().oneOf([
-          2,
-          2,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().oneOf(
+          [
+            2,
+            2,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model3]);
 
-        final notQ = isar.models.filter().not().oneOf([
-          2,
-          2,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().oneOf(
+          [
+            2,
+            2,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.filter().oneOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().oneOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
 
-        final notQ = isar.models.filter().not().oneOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().oneOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2, model3]);
       });
 
       isarTest('one matching and one non-matching elements', () async {
-        final q = isar.models.filter().oneOf([
-          7,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().oneOf(
+          [
+            7,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, [model3]);
 
-        final notQ = isar.models.filter().not().oneOf([
-          7,
-          3,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().oneOf(
+          [
+            7,
+            3,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2]);
       });
 
       isarTest('one non-matching element', () async {
-        final q = isar.models.filter().oneOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final q = isar.models.filter().oneOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(q, []);
 
-        final notQ = isar.models.filter().not().oneOf([
-          5,
-        ], (q, int element) => q.valueEqualTo(element));
+        final notQ = isar.models.filter().not().oneOf(
+          [
+            5,
+          ],
+          (q, int element) => q.valueEqualTo(element),
+        );
         await qEqual(notQ, [model0, model1, model2, model3]);
       });
     });

--- a/packages/isar_test/test/stress/twitter_test.dart
+++ b/packages/isar_test/test/stress/twitter_test.dart
@@ -27,86 +27,111 @@ import 'package:test/test.dart';
 
 void main() async {
   const skipStressTest = true;
-  group('Twitter Stress', () {
-    late Isar isar;
-    late IsarCollection<Tweet> col;
+  group(
+    'Twitter Stress',
+    () {
+      late Isar isar;
+      late IsarCollection<Tweet> col;
 
-    setUpAll(() async {
-      isar = await openTempIsar([TweetSchema], closeAutomatically: false);
-      col = isar.collection<Tweet>();
+      setUpAll(() async {
+        isar = await openTempIsar([TweetSchema], closeAutomatically: false);
+        col = isar.collection<Tweet>();
 
-      // for (var i = 0; i < 100; i++) {
-      //   final tweets = await downloadTweets(isar.directory!, i);
-      //   await isar.tWriteTxn(() async {
-      //     await col.tPutAll(tweets);
-      //   });
-      // }
-    });
+        // for (var i = 0; i < 100; i++) {
+        //   final tweets = await downloadTweets(isar.directory!, i);
+        //   await isar.tWriteTxn(() async {
+        //     await col.tPutAll(tweets);
+        //   });
+        // }
+      });
 
-    tearDownAll(() => isar.close(deleteFromDisk: true));
+      tearDownAll(() => isar.close(deleteFromDisk: true));
 
-    isarTest('Aggregation', () async {
-      expect(await col.where().tCount(), 500000);
-      expect(await col.where().favoriteCountProperty().tSum(), 307278);
-      expect(await col.where().favoriteCountProperty().tAverage(), 0.614556);
-      expect(await col.where().favoriteCountProperty().tMin(), 0);
-      expect(await col.where().favoriteCountProperty().tMax(), 2317);
+      isarTest(
+        'Aggregation',
+        () async {
+          expect(await col.where().tCount(), 500000);
+          expect(await col.where().favoriteCountProperty().tSum(), 307278);
+          expect(
+              await col.where().favoriteCountProperty().tAverage(), 0.614556);
+          expect(await col.where().favoriteCountProperty().tMin(), 0);
+          expect(await col.where().favoriteCountProperty().tMax(), 2317);
 
-      expect(
-        (await col.where().createdAtProperty().tMin())!.toUtc(),
-        DateTime.utc(2015, 4, 23, 9, 10, 58),
+          expect(
+            (await col.where().createdAtProperty().tMin())!.toUtc(),
+            DateTime.utc(2015, 4, 23, 9, 10, 58),
+          );
+          expect(
+            (await col.where().createdAtProperty().tMax())!.toUtc(),
+            DateTime.utc(2015, 6, 18, 10, 1, 57),
+          );
+        },
+        skip: skipStressTest,
       );
-      expect(
-        (await col.where().createdAtProperty().tMax())!.toUtc(),
-        DateTime.utc(2015, 6, 18, 10, 1, 57),
+
+      isarTest(
+        'Distinct',
+        () async {
+          await qEqualSet(col.where().distinctByLang().langProperty(), [
+            'en', 'it', 'de', 'fr', 'pt', 'und', 'es', 'qme', 'qht', //
+            'hu', 'ja', 'et', 'tl', 'eu', 'pl', 'ht', 'in', 'lt', 'ar', //
+            'ca', 'ru', 'el', 'ro', 'uk', 'sl', 'cy', 'no', 'nl', 'sv', //
+            'fi', 'zh', 'tr', 'cs', 'lv', 'hi', 'is', 'da', 'bg', 'vi', //
+            'ko', 'fa', 'th', 'sr', 'ne', 'ur', 'iw',
+          ]);
+        },
+        skip: skipStressTest,
       );
-    }, skip: skipStressTest);
 
-    isarTest('Distinct', () async {
-      await qEqualSet(col.where().distinctByLang().langProperty(), [
-        'en', 'it', 'de', 'fr', 'pt', 'und', 'es', 'qme', 'qht', //
-        'hu', 'ja', 'et', 'tl', 'eu', 'pl', 'ht', 'in', 'lt', 'ar', //
-        'ca', 'ru', 'el', 'ro', 'uk', 'sl', 'cy', 'no', 'nl', 'sv', //
-        'fi', 'zh', 'tr', 'cs', 'lv', 'hi', 'is', 'da', 'bg', 'vi', //
-        'ko', 'fa', 'th', 'sr', 'ne', 'ur', 'iw',
-      ]);
-    }, skip: skipStressTest);
+      isarTest(
+        'Sort by',
+        () async {
+          final query = col
+              .where()
+              .sortByFavoriteCount()
+              .thenByLang()
+              .thenByFullText()
+              .limit(5)
+              .isarIdProperty();
+          await qEqual(query, [458669, 441027, 368275, 222021, 368289]);
+        },
+        skip: skipStressTest,
+      );
 
-    isarTest('Sort by', () async {
-      final query = col
-          .where()
-          .sortByFavoriteCount()
-          .thenByLang()
-          .thenByFullText()
-          .limit(5)
-          .isarIdProperty();
-      await qEqual(query, [458669, 441027, 368275, 222021, 368289]);
-    }, skip: skipStressTest);
-
-    isarTest('Query', () async {
-      final complexQuery = col
-          .filter()
-          .not()
-          .group(
-            (q) =>
-                q.placeIsNull().or().entitiesIsNull().or().coordinatesIsNull(),
-          )
-          .not()
-          .inReplyToScreenNameIsNull()
-          // .entities(
-          //   (q) => q
-          //       .hashtagsLengthGreaterThan(0)
-          //       .urlsLengthGreaterThan(0)
-          //       .mediaLengthGreaterThan(0)
-          //       .userMentionsLengthGreaterThan(0),
-          // )
-          .idStrProperty();
-      await qEqual(complexQuery, [
-        '592572613462986752',
-        '596576703285174272',
-        '597445810696126464',
-        '602584278883553280',
-      ]);
-    }, skip: skipStressTest);
-  }, timeout: const Timeout(Duration(minutes: 10)));
+      isarTest(
+        'Query',
+        () async {
+          final complexQuery = col
+              .filter()
+              .not()
+              .group(
+                (q) => q
+                    .placeIsNull()
+                    .or()
+                    .entitiesIsNull()
+                    .or()
+                    .coordinatesIsNull(),
+              )
+              .not()
+              .inReplyToScreenNameIsNull()
+              // .entities(
+              //   (q) => q
+              //       .hashtagsLengthGreaterThan(0)
+              //       .urlsLengthGreaterThan(0)
+              //       .mediaLengthGreaterThan(0)
+              //       .userMentionsLengthGreaterThan(0),
+              // )
+              .idStrProperty();
+          await qEqual(complexQuery, [
+            '592572613462986752',
+            '596576703285174272',
+            '597445810696126464',
+            '602584278883553280',
+          ]);
+        },
+        skip: skipStressTest,
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
 }

--- a/packages/isar_test/test/stress/twitter_test.dart
+++ b/packages/isar_test/test/stress/twitter_test.dart
@@ -53,7 +53,9 @@ void main() async {
           expect(await col.where().tCount(), 500000);
           expect(await col.where().favoriteCountProperty().tSum(), 307278);
           expect(
-              await col.where().favoriteCountProperty().tAverage(), 0.614556);
+            await col.where().favoriteCountProperty().tAverage(),
+            0.614556,
+          );
           expect(await col.where().favoriteCountProperty().tMin(), 0);
           expect(await col.where().favoriteCountProperty().tMax(), 2317);
 


### PR DESCRIPTION
## Summary

Fix dart lint issues and CI configuration problems that cause failures unrelated to individual PR changes.

- Add required trailing commas (66 fixes across 13 files)
- Rename shadowing type parameter in `CollectionSchema.toCollection`
- Add explicit type annotation for `ObjectIndex.id`
- Move `test`/`test_api` from `dev_dependencies` to `dependencies` in `isar_test`
- Update outdated schema version in example generated files (`3.2.0-dev.2` -> `3.3.0`)
- Remove unsupported `macos-13` runner from CI test matrix (replaced by `macos-14`)
- Run `dart format` on all affected files

### Follow-up PRs

The following PRs depend on this one and will only be opened for review once #107 is merged:

- **#108** — Migrate easy `deprecated_member_use` (`dart:html`/`dart:indexed_db` -> `package:web`)
- **#109** — Migrate remaining JS interop (`dart:js`/`dart:js_util` -> `dart:js_interop`/`dart:js_interop_unsafe`)

Together, all three PRs resolve the pre-existing CI lint failures.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>