### PR TITLE
fix(inspector): add tooltip to show full schema name on hover

### DIFF
--- a/packages/isar_community_inspector/lib/collections_list.dart
+++ b/packages/isar_community_inspector/lib/collections_list.dart
@@ -30,51 +30,55 @@ class CollectionsList extends StatelessWidget {
 
         return Padding(
           padding: const EdgeInsets.only(bottom: 10),
-          child: ElevatedButton(
-            style: collection.name == selectedCollection
-                ? ElevatedButton.styleFrom(
-                    backgroundColor: theme.colorScheme.primaryContainer,
-                    foregroundColor: theme.colorScheme.onPrimaryContainer,
-                  )
-                : null,
-            onPressed: () {
-              onSelected(collection.name);
-            },
-            child: Padding(
-              padding: const EdgeInsets.only(
-                left: 25,
-                right: 10,
-                top: 12,
-                bottom: 12,
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      collection.name,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 16,
-                        overflow: TextOverflow.ellipsis,
+          child: Tooltip(
+            message: collection.name,
+            waitDuration: Duration.zero,
+            child: ElevatedButton(
+              style: collection.name == selectedCollection
+                  ? ElevatedButton.styleFrom(
+                      backgroundColor: theme.colorScheme.primaryContainer,
+                      foregroundColor: theme.colorScheme.onPrimaryContainer,
+                    )
+                  : null,
+              onPressed: () {
+                onSelected(collection.name);
+              },
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  left: 25,
+                  right: 10,
+                  top: 12,
+                  bottom: 12,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        collection.name,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
                     ),
-                  ),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        info?.count.toString() ?? 'loading',
-                        style: const TextStyle(fontSize: 12),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        _formatSize(info?.size ?? 0),
-                        style: const TextStyle(fontSize: 12),
-                      ),
-                    ],
-                  ),
-                ],
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          info?.count.toString() ?? 'loading',
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          _formatSize(info?.size ?? 0),
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Description

Fixes #105

This PR addresses the issue where the Isar Inspector sidebar truncates long schema names with an ellipsis, making it impossible to distinguish between schemas that share a long common prefix (e.g. `IsarNoteCommentMessageChat…` vs `IsarNoteCommentMessageEmoji…`).

### Changes Made:

**`isar_community_inspector` package:**
- Wrapped the `ElevatedButton` in `CollectionsList` with a `Tooltip` widget that shows the full schema name as its message.
- Set `waitDuration: Duration.zero` so the tooltip appears immediately on hover with no delay.
- The `Tooltip` is placed as the direct parent of `ElevatedButton` (not inside its child tree) because Flutter Web absorbs pointer hover events inside `ElevatedButton`, which prevents inner tooltip widgets from triggering.

### Testing
- Tested locally against an example app with schemas named `IsarNoteCommentMessageChatDataEntityState` and `IsarNoteCommentMessageEmojiReactedDataEntityState` — both show the full name on hover.
- Added 7 widget tests covering tooltip structure, message correctness, wait duration, text overflow, selection state, and tap interaction.
- `flutter analyze` reports no issues.

### Output
<img width="2884" height="1569" alt="image" src="https://github.com/user-attachments/assets/c7bae1a1-9205-4d1c-953e-9fe1cfceb2b9" />
