### PR TITLE
Update analyzer range.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -200,6 +200,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "westy92",
+      "name": "Seth Westphal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/290167?v=4",
+      "profile": "https://github.com/westy92",
+      "contributions": [
+        "maintenance"
+      ]
     }
   ],
   "contributorTemplate": "<a href=\"https://github.com/<%= contributor.login %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",

--- a/packages/isar_community_generator/pubspec.yaml
+++ b/packages/isar_community_generator/pubspec.yaml
@@ -19,7 +19,7 @@ platforms:
   windows:
 
 dependencies:
-  analyzer: ">=8.0.0 <11.0.0"
+  analyzer: ">=8.0.0 <14.0.0"
   build: ^4.0.0
   dart_style: ">=3.0.1 <4.0.0"
   dartx: ^1.1.0


### PR DESCRIPTION
The current range prevents using `mockito 5.7.0`:

```
Because mockito >=5.6.5 depends on analyzer ^13.0.0 and isar_community_generator 3.3.2 depends on analyzer >=8.0.0 <11.0.0, mockito >=5.6.5 is incompatible with isar_community_generator 3.3.2.
```