### PR TITLE
fix: persist auto-increment counter across database reopen

### DIFF
--- a/packages/isar_core/src/collection.rs
+++ b/packages/isar_core/src/collection.rs
@@ -28,6 +28,7 @@ pub struct IsarCollection {
 
     pub(crate) instance_id: u64,
     pub(crate) db: Db,
+    pub(crate) auto_increment_db: Db,
 
     pub(crate) indexes: Vec<IsarIndex>,
     pub(crate) links: Vec<IsarLink>, // links from this collection
@@ -43,6 +44,7 @@ impl IsarCollection {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         db: Db,
+        auto_increment_db: Db,
         instance_id: u64,
         name: &str,
         properties: Vec<Property>,
@@ -59,6 +61,7 @@ impl IsarCollection {
             embedded_properties,
             instance_id,
             db,
+            auto_increment_db,
             indexes,
             links,
             backlinks,
@@ -74,7 +77,31 @@ impl IsarCollection {
         QueryBuilder::new(self)
     }
 
+    fn auto_increment_key(&self) -> IndexKey {
+        IndexKey::from_bytes(self.name.as_bytes().to_vec())
+    }
+
+    fn persist_auto_increment(&self, cursors: &IsarCursors) -> Result<()> {
+        let key = self.auto_increment_key();
+        let value = self.auto_increment.get().to_le_bytes();
+        let mut cursor = cursors.get_cursor(self.auto_increment_db)?;
+        cursor.put(&key, &value)?;
+        Ok(())
+    }
+
     pub(crate) fn init_auto_increment(&self, cursors: &IsarCursors) -> Result<()> {
+        // Restore persisted high-water mark so deleted high-ID objects don't cause ID reuse
+        let ai_key = self.auto_increment_key();
+        {
+            let mut ai_cursor = cursors.get_cursor(self.auto_increment_db)?;
+            if let Some((_, bytes)) = ai_cursor.move_to(&ai_key)? {
+                if let Ok(arr) = bytes.try_into() {
+                    self.auto_increment.set(i64::from_le_bytes(arr));
+                }
+            }
+        }
+
+        // Also take max with the last ID actually in the B-tree (safety guard for existing dbs)
         let mut cursor = cursors.get_cursor(self.db)?;
         if let Some((key, _)) = cursor.move_to_last()? {
             let id = key.to_id();
@@ -184,6 +211,8 @@ impl IsarCollection {
         } else {
             self.auto_increment_internal()?
         };
+
+        self.persist_auto_increment(cursors)?;
 
         for index in &self.indexes {
             index.create_for_object(cursors, id, object, |id| {
@@ -298,6 +327,7 @@ impl IsarCollection {
             }
             cursors.clear_db(self.db)?;
             self.auto_increment.set(0);
+            self.persist_auto_increment(cursors)?;
 
             if let Some(change_set) = change_set {
                 change_set.register_all(self.id);

--- a/packages/isar_core/src/instance.rs
+++ b/packages/isar_core/src/instance.rs
@@ -112,7 +112,7 @@ impl IsarInstance {
 
         Self::move_old_database(name, dir, &isar_file);
 
-        let db_count = schema.count_dbs() as u64 + 3;
+        let db_count = schema.count_dbs() as u64 + 4; // +1 for _info, +1 for _autoincrement, +2 buffer
         let env = Env::create(
             &isar_file,
             db_count,

--- a/packages/isar_core/src/instance.rs
+++ b/packages/isar_core/src/instance.rs
@@ -348,6 +348,7 @@ impl IsarInstance {
     pub fn verify(&self, txn: &mut IsarTxn) -> Result<()> {
         let mut db_names = vec![];
         db_names.push("_info".to_string());
+        db_names.push("_autoincrement".to_string());
         for col in &self.collections {
             db_names.push(col.name.clone());
             for index in &col.indexes {

--- a/packages/isar_core/src/schema/schema_manager.rs
+++ b/packages/isar_core/src/schema/schema_manager.rs
@@ -32,6 +32,7 @@ static OLD_INFO_SCHEMA_KEY: Lazy<IndexKey> = Lazy::new(|| {
 pub(crate) struct SchemaManager {
     instance_id: u64,
     info_db: Db,
+    auto_increment_db: Db,
     pub schemas: Vec<CollectionSchema>,
 }
 
@@ -40,6 +41,7 @@ impl SchemaManager {
 
     pub fn create(instance_id: u64, txn: &Txn) -> Result<Self> {
         let info_db = Db::open(txn, Some("_info"), false, false, false)?;
+        let auto_increment_db = Db::open(txn, Some("_autoincrement"), false, false, false)?;
         let mut info_cursor = UnboundCursor::new().bind(txn, info_db)?;
 
         Self::migrate_old_info(&mut info_cursor)?;
@@ -48,6 +50,7 @@ impl SchemaManager {
         let manager = SchemaManager {
             instance_id,
             info_db,
+            auto_increment_db,
             schemas,
         };
         Ok(manager)
@@ -239,6 +242,7 @@ impl SchemaManager {
         let backlinks = Self::open_backlinks(txn, db, &schema, schemas)?;
         let col = IsarCollection::new(
             db,
+            self.auto_increment_db,
             self.instance_id,
             &schema.name,
             properties,


### PR DESCRIPTION
The auto-increment counter was stored only in memory and re-derived from the highest ID present in the B-tree on each open. Deleting objects with high IDs caused the counter to reset, reusing IDs on the next session — contradicting the documented guarantee.

Fix: persist the high-water mark in a dedicated '_autoincrement' MDBX database (keyed by collection name) on every put() and clear(), within the same transaction as the data. On open, the counter is seeded from max(persisted_value, max_id_in_btree).

Also increment db_count by 1 in instance.rs to reserve a slot for the new named database.

Fixes https://github.com/isar-community/isar-community/issues/115